### PR TITLE
WIP : 🚑 Remove provider locking 

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,3 @@
-provider "google" {
-  version = "2.17.0"
-}
-
-provider "tls" {
-  version = "2.1.0"
-}
-
 resource "google_service_account" "elasticsearch_backup" {
   account_id   = "elasticsearch-backup"
   display_name = "elasticsearch-backup"


### PR DESCRIPTION
(blocked using, because there is no 2.1.0 version of TLS)

https://github.com/AckeeCZ/terraform-elasticsearch/commit/d087c9afbb32e10d317f8ca9e0f480f14d692f0d